### PR TITLE
Enhancement: add / fix turndown rules, improve CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,30 +16,38 @@ $ npm i -g wp-handbook-converter
 $ yarn global add wp-handbook-converter
 ```
 
-If you want to run the command without installing the package, use this: `$ npx wp-handbook-converter <team>`
+If you want to run the command without installing the package, use this: `$ npx wp-handbook-converter`
 
-## `wp-handbook-converter` command
+## `wp-handbook-converter` command options
 
-```bash
-$ wp-handbook-converter <team>
-```
-
-### options
-
+- `-t, --team` &lt;team&gt; Specify team name.
 - `-b, --handbook` &lt;handbook&gt; Specify handbook name. (Default "handbook")
 - `-s, --sub-domain` &lt;sub-domain&gt; Specify subdomain name. e.g. "developer" for developer.w.org, "w.org" for w.org (Default "make")
 - `-o, --output-dir` &lt;output-dir&gt; Specify the directory to save files (default `en/`)
+- `-r, --regenerate` &lt;regenerate&gt; If this option is supplied, the directory you specified as output directory will once deleted, and it will regenerate all the files in the directory
 
 ### Example
 
-Get Meetup Handbook
+Get Core Contributor Handbook
 
 ```bash
-$ wp-handbook-converter community --handbook meetup-handbook
+$ wp-handbook-converter --team core
 ```
 
-Get theme developer Handbook
+Get Meetup Organizer Handbook
 
-```bash∑
-$ wp-handbook-converter '' --handbook theme-handbook --sub-domain developer
+```bash
+$ wp-handbook-converter --team community --handbook meetup-handbook
+```
+
+Get theme Handbook
+
+```bash
+$ wp-handbook-converter --handbook theme-handbook --sub-domain developer
+```
+
+Get plugin Handbook
+
+```bash
+$ wp-handbook-converter --handbook plugin-handbook --sub-domain developer
 ```

--- a/cli.js
+++ b/cli.js
@@ -260,6 +260,7 @@ const generateJson = async (
 
 program
   .version(packageJson.version)
+  .description('Generate a menu JSON file for WordPress.org handbook')
   .option(
     '-t, --team <team>',
     'Specify team name'

--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ const mkdirp = require('mkdirp')
 const del = require('del')
 const WPAPI = require('wpapi')
 const TurndownService = require('turndown')
-const {tables}  = require('turndown-plugin-gfm')
+const { tables } = require('turndown-plugin-gfm')
 
 // Languages that can be specified in the code markdown
 const codeLanguages = {
@@ -44,61 +44,68 @@ const turndownService = new TurndownService({
   codeBlockStyle: 'fenced',
   emDelimiter: '*',
 })
-turndownService.use(tables);
+turndownService.use(tables)
 
 // Remove Glossary
 turndownService.addRule('glossary', {
-  filter: node => {
-    const classList = node.getAttribute('class');
-    if ( classList ) {
-      return classList === 'glossary-item-hidden-content';
+  filter: (node) => {
+    const classList = node.getAttribute('class')
+    if (classList) {
+      return classList === 'glossary-item-hidden-content'
     }
-    return false;
+    return false
   },
   replacement: () => {
-    return '';
-  }
-});
+    return ''
+  },
+})
 
 // Remove code trigger anchor
 turndownService.addRule('code-trigger-anchor', {
-  filter: node => {
-    const classList = node.getAttribute('class');
-    if ( classList ) {
-      return classList.includes('show-complete-source') || classList.includes(`less-complete-source`);
+  filter: (node) => {
+    const classList = node.getAttribute('class')
+    if (classList) {
+      return (
+        classList.includes('show-complete-source') ||
+        classList.includes(`less-complete-source`)
+      )
     }
-    return false;
+    return false
   },
   replacement: () => {
-    return '';
-  }
-});
+    return ''
+  },
+})
 
 // Transform dt tag to strong tag
 turndownService.addRule('dt-to-strong', {
   filter: ['dt'],
   replacement: (content, node, options) => {
     return options.strongDelimiter + content + options.strongDelimiter
-  }
-});
+  },
+})
 
 // Transform pre code block to code markdown
 turndownService.addRule('precode to code', {
-  filter: node => {
-    const classList = node.getAttribute('class');
-    const isCode = node.nodeName === 'PRE' && classList && classList.includes('brush:');
-    return isCode;
+  filter: (node) => {
+    const classList = node.getAttribute('class')
+    const isCode =
+      node.nodeName === 'PRE' && classList && classList.includes('brush:')
+    return isCode
   },
   replacement: (content, node) => {
-    const classList = node.getAttribute('class');
+    const classList = node.getAttribute('class')
 
     // Search for a language that matches the list of code languages
-    const codeLanguage = Object.keys(codeLanguages).reduce((currentLanguage, language) => {
-      if ( classList.includes(language) ) {
-        return codeLanguages[language];
-      }
-      return currentLanguage;
-    }, undefined);
+    const codeLanguage = Object.keys(codeLanguages).reduce(
+      (currentLanguage, language) => {
+        if (classList.includes(language)) {
+          return codeLanguages[language]
+        }
+        return currentLanguage
+      },
+      undefined
+    )
 
     // Unescape contents
     let newContent = unEscapes.reduce((accumulator, unEscape) => {
@@ -106,17 +113,17 @@ turndownService.addRule('precode to code', {
     }, content)
 
     // Remove br tag
-    newContent = newContent.replace(/^<br \/>\n\n|<br \/>\n/g, "\n");
+    newContent = newContent.replace(/^<br \/>\n\n|<br \/>\n/g, '\n')
     // Remove first and last paragraph tag
-    newContent = newContent.replace(/^<\/p>|<p>$/g, '');
+    newContent = newContent.replace(/^<\/p>|<p>$/g, '')
     // Remove first new line
-    newContent = newContent.replace(/^\n/, '');
+    newContent = newContent.replace(/^\n/, '')
     // Convert to language-aware markdown
-    newContent = '```' + (codeLanguage ?? '') + "\n" + newContent + '```';
+    newContent = '```' + (codeLanguage ?? '') + '\n' + newContent + '```'
 
-    return newContent;
-  }
-});
+    return newContent
+  },
+})
 
 const getAll = (request) => {
   return request.then((response) => {
@@ -124,10 +131,9 @@ const getAll = (request) => {
       return response
     }
     // Request the next page and return both responses as one collection
-    return Promise.all([
-      response,
-      getAll(response._paging.next),
-    ]).then((responses) => responses.flat())
+    return Promise.all([response, getAll(response._paging.next)]).then(
+      (responses) => responses.flat()
+    )
   })
 }
 
@@ -167,7 +173,6 @@ const generateJson = async (
     endpoint: `https://${subdomain}wordpress.org/${team}wp-json`,
   })
 
-
   wp.handbooks = wp.registerRoute('wp/v2', `/${handbook}/(?P<id>)`)
 
   console.log(
@@ -197,7 +202,7 @@ const generateJson = async (
           ? path.substring(0, path.lastIndexOf('/')) + '/'
           : ''
 
-      const content = item.content.rendered;
+      const content = item.content.rendered
       const markdownContent = turndownService.turndown(content)
       const markdown = `# ${item.title.rendered}\n\n${markdownContent}`
 
@@ -261,10 +266,7 @@ const generateJson = async (
 program
   .version(packageJson.version)
   .description('Generate a menu JSON file for WordPress.org handbook')
-  .option(
-    '-t, --team <team>',
-    'Specify team name'
-  )
+  .option('-t, --team <team>', 'Specify team name')
   .option(
     '-b, --handbook <handbook>',
     'Specify handbook name (default "handbook")'

--- a/cli.js
+++ b/cli.js
@@ -92,7 +92,7 @@ turndownService.addRule('precode to code', {
   replacement: (content, node) => {
     const classList = node.getAttribute('class');
 
-    // Search for a language that is match the list of code languages
+    // Search for a language that matches the list of code languages
     const codeLanguage = Object.keys(codeLanguages).reduce((currentLanguage, language) => {
       if ( classList.includes(language) ) {
         return codeLanguages[language];

--- a/cli.js
+++ b/cli.js
@@ -8,12 +8,115 @@ const { program } = require('commander')
 const mkdirp = require('mkdirp')
 const del = require('del')
 const WPAPI = require('wpapi')
-const turndown = require('turndown')
-const turndownService = new turndown({
+const TurndownService = require('turndown')
+const {tables}  = require('turndown-plugin-gfm')
+
+// Languages that can be specified in the code markdown
+const codeLanguages = {
+  css: 'css',
+  bash: 'bash',
+  php: 'php',
+  yaml: 'yaml',
+  xml: 'xml',
+  jscript: 'javascript',
+}
+
+// Rules that remove escapes in code blocks
+const unEscapes = [
+  [/\\\\/g, '\\'],
+  [/\\\*/g, '*'],
+  [/\\-/g, '-'],
+  [/^\\+ /g, '+ '],
+  [/\\=/g, '='],
+  [/\\`/g, '`'],
+  [/\\~~~/g, '~~~'],
+  [/\\\[/g, '['],
+  [/\\\]/g, ']'],
+  [/\\>/g, '>'],
+  [/\\_/g, '_'],
+  [/\&quot;/g, '"'],
+  [/\&lt;/g, '<'],
+  [/\&gt;/g, '>'],
+]
+
+const turndownService = new TurndownService({
   headingStyle: 'atx',
   codeBlockStyle: 'fenced',
   emDelimiter: '*',
 })
+turndownService.use(tables);
+
+// Remove Glossary
+turndownService.addRule('glossary', {
+  filter: node => {
+    const classList = node.getAttribute('class');
+    if ( classList ) {
+      return classList === 'glossary-item-hidden-content';
+    }
+    return false;
+  },
+  replacement: () => {
+    return '';
+  }
+});
+
+// Remove code trigger anchor
+turndownService.addRule('code-trigger-anchor', {
+  filter: node => {
+    const classList = node.getAttribute('class');
+    if ( classList ) {
+      return classList.includes('show-complete-source') || classList.includes(`less-complete-source`);
+    }
+    return false;
+  },
+  replacement: () => {
+    return '';
+  }
+});
+
+// Transform dt tag to strong tag
+turndownService.addRule('dt-to-strong', {
+  filter: ['dt'],
+  replacement: (content, node, options) => {
+    return options.strongDelimiter + content + options.strongDelimiter
+  }
+});
+
+// Transform pre code block to code markdown
+turndownService.addRule('precode to code', {
+  filter: node => {
+    const classList = node.getAttribute('class');
+    const isCode = node.nodeName === 'PRE' && classList && classList.includes('brush:');
+    return isCode;
+  },
+  replacement: (content, node) => {
+    const classList = node.getAttribute('class');
+
+    // Search for a language that is match the list of code languages
+    const codeLanguage = Object.keys(codeLanguages).reduce((currentLanguage, language) => {
+      if ( classList.includes(language) ) {
+        return codeLanguages[language];
+      }
+      return currentLanguage;
+    }, undefined);
+
+    // Unescape contents
+    let newContent = unEscapes.reduce((accumulator, unEscape) => {
+      return accumulator.replace(unEscape[0], unEscape[1])
+    }, content)
+
+    // Remove br tag
+    newContent = newContent.replace(/^<br \/>\n\n|<br \/>\n/g, "\n");
+    // Remove first and last paragraph tag
+    newContent = newContent.replace(/^<\/p>|<p>$/g, '');
+    // Remove first new line
+    newContent = newContent.replace(/^\n/, '');
+    // Convert to language-aware markdown
+    newContent = codeLanguage ? `\`\`\`${codeLanguage}\n` + newContent + '```' : "```\n" + newContent + '```';
+
+    return newContent;
+  }
+});
 
 const getAll = (request) => {
   return request.then((response) => {
@@ -35,6 +138,7 @@ const generateJson = async (
   outputDir,
   regenerate
 ) => {
+  team = team ? `${team}/` : ''
   handbook = handbook ? handbook : 'handbook'
   subdomain = `${
     subdomain ? (subdomain === 'w.org' ? '' : subdomain) : 'make'
@@ -60,12 +164,14 @@ const generateJson = async (
     })
 
   const wp = new WPAPI({
-    endpoint: `https://${subdomain}wordpress.org/${team}/wp-json`,
+    endpoint: `https://${subdomain}wordpress.org/${team}wp-json`,
   })
+
+
   wp.handbooks = wp.registerRoute('wp/v2', `/${handbook}/(?P<id>)`)
 
   console.log(
-    `Connecting to https://${subdomain}wordpress.org/${team}/wp-json/wp/v2/${handbook}/`
+    `Connecting to https://${subdomain}wordpress.org/${team}wp-json/wp/v2/${handbook}/`
   )
 
   getAll(wp.handbooks()).then(async (allPosts) => {
@@ -83,18 +189,16 @@ const generateJson = async (
         rootPath = `https://${subdomain}wordpress.org/${team}/${handbook}/`
       }
     }
+
     for (const item of allPosts) {
       const path = item.link.split(rootPath)[1].replace(/\/$/, '') || 'index'
       const filePath =
         path.split('/').length > 1
           ? path.substring(0, path.lastIndexOf('/')) + '/'
           : ''
-      // remove <span class='glossary-item-hidden-content'>inner contents
-      const preContent = item.content.rendered.replace(
-        /<span class=\'glossary-item-hidden-content\'>.*?<\/span><\/span>/g,
-        ''
-      )
-      const markdownContent = turndownService.turndown(preContent)
+
+      const content = item.content.rendered;
+      const markdownContent = turndownService.turndown(content)
       const markdown = `# ${item.title.rendered}\n\n${markdownContent}`
 
       await mkdirp(`${outputDir}/${filePath}`)
@@ -156,8 +260,10 @@ const generateJson = async (
 
 program
   .version(packageJson.version)
-  .arguments('<team>')
-  .description('Generate a menu JSON file for WordPress.org handbook')
+  .option(
+    '-t, --team <team>',
+    'Specify team name'
+  )
   .option(
     '-b, --handbook <handbook>',
     'Specify handbook name (default "handbook")'
@@ -174,9 +280,9 @@ program
     '-r --regenerate',
     'If this option is supplied, the directory you specified as output directory will once deleted, and it will regenerate all the files in the directory'
   )
-  .action((team, options) => {
+  .action((options) => {
     generateJson(
-      team,
+      options.team,
       options.handbook,
       options.subDomain,
       options.outputDir,

--- a/cli.js
+++ b/cli.js
@@ -112,7 +112,7 @@ turndownService.addRule('precode to code', {
     // Remove first new line
     newContent = newContent.replace(/^\n/, '');
     // Convert to language-aware markdown
-    newContent = codeLanguage ? `\`\`\`${codeLanguage}\n` + newContent + '```' : "```\n" + newContent + '```';
+    newContent = '```' + (codeLanguage ?? '') + "\n" + newContent + '```';
 
     return newContent;
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "del": "^6.0.0",
     "mkdirp": "^1.0.0",
     "turndown": "^7.0.0",
+    "turndown-plugin-gfm": "^1.0.2",
     "wpapi": "^1.1.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+turndown-plugin-gfm@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
+  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
 turndown@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"


### PR DESCRIPTION
はじめまして。
現在コアコントリビューターハンドブックの日本語化を進めており、こちらのライブラリを使わせていいただいています。

主に、より正確にパース出来るようにするために、以下の変更を加えさせていただきました。

- 一部 glossary が除去出来ていなかった点を修正
- `dt` タグを `srong` タグに変換（dtタグはマークダウンでは使えないため、strongタグで代用する）
- コードブロックをマークダウンに変換する
  - コード内の文字がエスケープされないように修正
  - コードブロックのクラス名から言語を読み取り、マークダウンにもその言語を付与する（例：```php）
  - テーブルタグのサポート（theadが無いテーブルは、https://github.com/mixmark-io/turndown-plugin-gfm/pull/10によりHTMLのままマークダウンファイルにも反映されてしまうので、完全ではありません）
- CLIの引数 `team` を 必須から任意に変更（ここが必須だと、正しいエンドポイントを指定出来ないハンドブックが存在したため）

一度に多くの変更を加えてしまい申し訳ないのですが、ご確認いただけると幸いです。